### PR TITLE
change node-mime dependancy to forked repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "event-stream": "*",
     "gulp-util": "~2.2.6",
     "knox": "",
-    "mime": "~1.2.11"
+    "mime": "ScottVanderZwet/node-mime"
   },
   "devDependencies": {
     "mocha": "~1.14.0",


### PR DESCRIPTION
[Trello](https://trello.com/c/NLrmBuLT/6928-social-hub-set-content-type-header-when-deploying-social-hub-css-gz-or-js-gz-files)
